### PR TITLE
Update to May's breaking changes

### DIFF
--- a/Items/Consumable/DeathEmblem.cs
+++ b/Items/Consumable/DeathEmblem.cs
@@ -25,7 +25,7 @@ namespace GoldensMisc.Items.Consumable
 			Item.height = 18;
 			Item.useStyle = ItemUseStyleID.HoldUp;
 			Item.useTime = 90;
-			Item.UseSound = new LegacySoundStyle(SoundID.MoonLord, 0);
+			Item.UseSound = SoundID.MoonLord;
 			Item.useAnimation = 90;
 			Item.rare = ItemRarityID.LightRed;
 			Item.value = Item.sellPrice(0, 0, 50);
@@ -40,7 +40,7 @@ namespace GoldensMisc.Items.Consumable
 		
 		public override bool? UseItem(Player player)
 		{
-			if (Main.rand.Next(2) == 0)
+			if (Main.rand.NextBool(2))
 				Dust.NewDust(player.position, player.width, player.height, DustID.MagicMirror, 0.0f, 0.0f, 150, Color.Red, 1.1f);
 			if (player.itemAnimation == Item.useAnimation / 2)
 			{

--- a/Items/Consumable/LifeStone.cs
+++ b/Items/Consumable/LifeStone.cs
@@ -25,13 +25,6 @@ namespace GoldensMisc.Items.Consumable
 		byte uses = 0;
 		const byte maxUses = 90;
 
-		public override ModItem Clone(Item item)
-		{
-			LifeStone clone = (LifeStone)base.Clone(item);
-			clone.uses = 0;
-			return clone;
-		}
-
 		public override void SetDefaults()
 		{
 			Item.width = 26;

--- a/Items/Consumable/ManaStone.cs
+++ b/Items/Consumable/ManaStone.cs
@@ -24,13 +24,6 @@ namespace GoldensMisc.Items.Consumable
 		byte uses = 0;
 		const byte maxUses = 60;
 
-		public override ModItem Clone(Item item)
-		{
-			ManaStone clone = (ManaStone)base.Clone(item);
-			clone.uses = 0;
-			return clone;
-		}
-
 		public override void SetDefaults()
 		{
 			Item.width = 26;

--- a/Projectiles/MagicSpear.cs
+++ b/Projectiles/MagicSpear.cs
@@ -55,7 +55,7 @@ namespace GoldensMisc.Projectiles
 		
 		public override void Kill(int timeLeft)
 		{
-			SoundEngine.PlaySound(SoundID.Item, Projectile.position, 10);
+			SoundEngine.PlaySound(SoundID.Item10, Projectile.position);
 			for (int i = 0; i < 4; i++)
 			{
 				int dust = Dust.NewDust(Projectile.position, Projectile.width, Projectile.height, DustID.BlueTorch, Projectile.velocity.X, Projectile.velocity.Y);

--- a/Projectiles/UndyingSpear.cs
+++ b/Projectiles/UndyingSpear.cs
@@ -50,7 +50,7 @@ namespace GoldensMisc.Projectiles
 		
 		public override void Kill(int timeLeft)
 		{
-			SoundEngine.PlaySound(SoundID.Item, Projectile.position, 10);
+			SoundEngine.PlaySound(SoundID.Item10, Projectile.position);
 			for (int i = 0; i < 5; i++)
 			{
 				int dust = Dust.NewDust(Projectile.position, Projectile.width, Projectile.height, DustID.BlueTorch, Projectile.velocity.X, Projectile.velocity.Y);

--- a/build.txt
+++ b/build.txt
@@ -1,6 +1,6 @@
 ﻿displayName = Miscellania
 author = gardenapple
-version = 1.7.14
+version = 1.7.15
 homepage = http://forums.terraria.org/index.php?threads/miscellania.39500/
 hideResources = false
 hideCode = false


### PR DESCRIPTION
- Update to May's breaking changes.
- Stop overriding Clone for the stones since apparently some types are handled correctly automatically.
- Start slowly moving from Next to NextBool.