### PR TITLE
Fixing Up Things

### DIFF
--- a/Items/Tools/RodofWarping.cs
+++ b/Items/Tools/RodofWarping.cs
@@ -10,7 +10,7 @@ using Microsoft.Xna.Framework.Graphics;
 
 namespace GoldensMisc.Items.Tools
 {
-	public class RodofWarping : ModItem
+	public class RodofWarping : GlowingModItem
 	{
 
 		public override bool IsLoadingEnabled (Mod mod)
@@ -36,6 +36,7 @@ namespace GoldensMisc.Items.Tools
 			Item.UseSound = SoundID.Item8;
 			Item.rare = ItemRarityID.Red;
 			Item.value = Item.sellPrice(0, 20);
+			GlowMask = MiscGlowMasks.RodofWarping;
 		}
 		
 		public override bool? UseItem(Player player)
@@ -72,25 +73,6 @@ namespace GoldensMisc.Items.Tools
 			return true;
 		}
 
-		public override void PostDrawInInventory(SpriteBatch spriteBatch, Vector2 position, Rectangle frame, Color drawColor, Color itemColor, Vector2 origin, float scale)
-		{
-			Texture2D glowTexture = MiscGlowMasks.RodofWarping;
-			Color color = Color.White;
-			color.A = 255;
-			spriteBatch.Draw(glowTexture, position, frame, color, 0f, origin, scale, SpriteEffects.None, 0f);
-		}
-
-		public override void PostDrawInWorld(SpriteBatch spriteBatch, Color lightColor, Color alphaColor, float rotation, float scale, int whoAmI)
-		{
-			Texture2D glowTexture = MiscGlowMasks.RodofWarping;
-			Color color = Color.White;
-			color.A = 255;
-			Rectangle glowTextureSize = new(0, 0, glowTexture.Width, glowTexture.Height);
-			Vector2 glowTextureOrigin = glowTexture.Size() * .5f;
-			Vector2 glowOffset = new((float)(Item.width / 2) - glowTextureOrigin.X, (float)(Item.height - glowTexture.Height));
-			Vector2 glowPosition = Item.position - Main.screenPosition + glowTextureOrigin + glowOffset;
-			spriteBatch.Draw(glowTexture, glowPosition, glowTextureSize, color, rotation, glowTextureOrigin, scale, SpriteEffects.None, 0f);
-		}
 
 		public override void AddRecipes()
 		{

--- a/Items/Tools/RodofWarping.cs
+++ b/Items/Tools/RodofWarping.cs
@@ -6,7 +6,7 @@ using Terraria.DataStructures;
 using Terraria.ID;
 using Terraria.GameContent.Creative;
 using Terraria.ModLoader;
-
+using Microsoft.Xna.Framework.Graphics;
 
 namespace GoldensMisc.Items.Tools
 {
@@ -36,7 +36,6 @@ namespace GoldensMisc.Items.Tools
 			Item.UseSound = SoundID.Item8;
 			Item.rare = ItemRarityID.Red;
 			Item.value = Item.sellPrice(0, 20);
-			Item.glowMask = MiscGlowMasks.RodofWarping;
 		}
 		
 		public override bool? UseItem(Player player)
@@ -72,7 +71,27 @@ namespace GoldensMisc.Items.Tools
 			}
 			return true;
 		}
-		
+
+		public override void PostDrawInInventory(SpriteBatch spriteBatch, Vector2 position, Rectangle frame, Color drawColor, Color itemColor, Vector2 origin, float scale)
+		{
+			Texture2D glowTexture = MiscGlowMasks.RodofWarping;
+			Color color = Color.White;
+			color.A = 255;
+			spriteBatch.Draw(glowTexture, position, frame, color, 0f, origin, scale, SpriteEffects.None, 0f);
+		}
+
+		public override void PostDrawInWorld(SpriteBatch spriteBatch, Color lightColor, Color alphaColor, float rotation, float scale, int whoAmI)
+		{
+			Texture2D glowTexture = MiscGlowMasks.RodofWarping;
+			Color color = Color.White;
+			color.A = 255;
+			Rectangle glowTextureSize = new(0, 0, glowTexture.Width, glowTexture.Height);
+			Vector2 glowTextureOrigin = glowTexture.Size() * .5f;
+			Vector2 glowOffset = new((float)(Item.width / 2) - glowTextureOrigin.X, (float)(Item.height - glowTexture.Height));
+			Vector2 glowPosition = Item.position - Main.screenPosition + glowTextureOrigin + glowOffset;
+			spriteBatch.Draw(glowTexture, glowPosition, glowTextureSize, color, rotation, glowTextureOrigin, scale, SpriteEffects.None, 0f);
+		}
+
 		public override void AddRecipes()
 		{
 			CreateRecipe()

--- a/Items/Weapons/UndyingSpear.cs
+++ b/Items/Weapons/UndyingSpear.cs
@@ -10,7 +10,7 @@ using Microsoft.Xna.Framework;
 
 namespace GoldensMisc.Items.Weapons
 {
-	public class UndyingSpear : ModItem
+	public class UndyingSpear : GlowingModItem
 	{
 		public override void SetStaticDefaults()
 		{
@@ -42,26 +42,7 @@ namespace GoldensMisc.Items.Weapons
 			Item.noUseGraphic = true; //No swing animation
 			Item.DamageType = DamageClass.Magic;
 			Item.crit = 10;
-		}
-
-		public override void PostDrawInInventory(SpriteBatch spriteBatch, Vector2 position, Rectangle frame, Color drawColor, Color itemColor, Vector2 origin, float scale)
-		{
-			Texture2D glowTexture = MiscGlowMasks.UndyingSpear;
-			Color color = Color.White;
-			color.A = 255;
-			spriteBatch.Draw(glowTexture, position, frame, color, 0f, origin, scale, SpriteEffects.None, 0f);
-		}
-
-		public override void PostDrawInWorld(SpriteBatch spriteBatch, Color lightColor, Color alphaColor, float rotation, float scale, int whoAmI)
-		{
-			Texture2D glowTexture = MiscGlowMasks.UndyingSpear;
-			Color color = Color.White;
-			color.A = 255;
-			Rectangle glowTextureSize = new(0, 0, glowTexture.Width, glowTexture.Height);
-			Vector2 glowTextureOrigin = glowTexture.Size() * .5f;
-			Vector2 glowOffset = new ((float)(Item.width / 2) - glowTextureOrigin.X, (float)(Item.height - glowTexture.Height));
-			Vector2 glowPosition = Item.position - Main.screenPosition + glowTextureOrigin + glowOffset;
-			spriteBatch.Draw(glowTexture, glowPosition, glowTextureSize, color, rotation, glowTextureOrigin, scale, SpriteEffects.None, 0f);
+			GlowMask = MiscGlowMasks.UndyingSpear;
 		}
 
 		public override void AddRecipes()

--- a/Items/Weapons/UndyingSpear.cs
+++ b/Items/Weapons/UndyingSpear.cs
@@ -5,6 +5,8 @@ using Terraria;
 using Terraria.ID;
 using Terraria.GameContent.Creative;
 using Terraria.ModLoader;
+using Microsoft.Xna.Framework.Graphics;
+using Microsoft.Xna.Framework;
 
 namespace GoldensMisc.Items.Weapons
 {
@@ -40,9 +42,28 @@ namespace GoldensMisc.Items.Weapons
 			Item.noUseGraphic = true; //No swing animation
 			Item.DamageType = DamageClass.Magic;
 			Item.crit = 10;
-			Item.glowMask = MiscGlowMasks.UndyingSpear;
 		}
-		
+
+		public override void PostDrawInInventory(SpriteBatch spriteBatch, Vector2 position, Rectangle frame, Color drawColor, Color itemColor, Vector2 origin, float scale)
+		{
+			Texture2D glowTexture = MiscGlowMasks.UndyingSpear;
+			Color color = Color.White;
+			color.A = 255;
+			spriteBatch.Draw(glowTexture, position, frame, color, 0f, origin, scale, SpriteEffects.None, 0f);
+		}
+
+		public override void PostDrawInWorld(SpriteBatch spriteBatch, Color lightColor, Color alphaColor, float rotation, float scale, int whoAmI)
+		{
+			Texture2D glowTexture = MiscGlowMasks.UndyingSpear;
+			Color color = Color.White;
+			color.A = 255;
+			Rectangle glowTextureSize = new(0, 0, glowTexture.Width, glowTexture.Height);
+			Vector2 glowTextureOrigin = glowTexture.Size() * .5f;
+			Vector2 glowOffset = new ((float)(Item.width / 2) - glowTextureOrigin.X, (float)(Item.height - glowTexture.Height));
+			Vector2 glowPosition = Item.position - Main.screenPosition + glowTextureOrigin + glowOffset;
+			spriteBatch.Draw(glowTexture, glowPosition, glowTextureSize, color, rotation, glowTextureOrigin, scale, SpriteEffects.None, 0f);
+		}
+
 		public override void AddRecipes()
 		{
 			CreateRecipe()
@@ -51,5 +72,5 @@ namespace GoldensMisc.Items.Weapons
 				.AddTile(TileID.MythrilAnvil)
 				.Register();
 		}
-	}
+    }
 }

--- a/MiscGlowMasks.cs
+++ b/MiscGlowMasks.cs
@@ -9,52 +9,31 @@ namespace GoldensMisc
 {
 	public static class MiscGlowMasks
 	{
-		public static short UndyingSpear;
-		public static short UndyingSpearProjectile;
-		public static short RodofWarping;
-		const short Count = 3;
-		static short End;
+		public static Texture2D UndyingSpear;
+		public static Texture2D UndyingSpearProjectile;
+		public static Texture2D RodofWarping;
 		public static bool Loaded;
 		
 		public static void Load()
 		{
-			Array.Resize(ref TextureAssets.GlowMask, TextureAssets.GlowMask.Length + Count);
+			if (!Loaded)
+            {
+				UndyingSpear = ModContent.Request<Texture2D>("GoldensMisc/Items/Weapons/UndyingSpear_Glow", ReLogic.Content.AssetRequestMode.ImmediateLoad).Value;
+				UndyingSpearProjectile = ModContent.Request<Texture2D>("GoldensMisc/Projectiles/UndyingSpear_Glow", ReLogic.Content.AssetRequestMode.ImmediateLoad).Value;
+				RodofWarping = ModContent.Request<Texture2D>("GoldensMisc/Items/Tools/RodofWarping_Glow", ReLogic.Content.AssetRequestMode.ImmediateLoad).Value;
+				Loaded = true;
+			}
 			
-			short i = (short)(TextureAssets.GlowMask.Length - Count);
-			TextureAssets.GlowMask[i] = ModContent.Request<Texture2D>("GoldensMisc/Items/Weapons/UndyingSpear_Glow");
-			UndyingSpear = i;
-			i++;
-			TextureAssets.GlowMask[i] = ModContent.Request<Texture2D>("GoldensMisc/Projectiles/UndyingSpear_Glow");
-			UndyingSpearProjectile = i;
-			i++;
-			TextureAssets.GlowMask[i] = ModContent.Request<Texture2D>("GoldensMisc/Items/Tools/RodofWarping_Glow");
-			RodofWarping = i;
-			i++;
-			End = i;
-			
-			Loaded = true;
 		}
 		
 		public static void Unload()
 		{
 			if(Loaded)
 			{
-				//Remove our glow masks so the mod can unload properly(?)
-				TextureAssets.GlowMask[UndyingSpear] = null;
-				TextureAssets.GlowMask[UndyingSpearProjectile] = null;
-				TextureAssets.GlowMask[RodofWarping] = null;
-
-				//Shrink array back to original if possible
-				if(TextureAssets.GlowMask.Length == End)
-				{
-					Array.Resize(ref TextureAssets.GlowMask, TextureAssets.GlowMask.Length - Count);
-				}
-
+				UndyingSpear = null;
+				UndyingSpearProjectile = null;
+				RodofWarping = null;
 				Loaded = false;
-				UndyingSpear = 0;
-				UndyingSpearProjectile = 0;
-				RodofWarping = 0;
-				End = 0;
 			}
 		}
 	}

--- a/MiscGlowMasks.cs
+++ b/MiscGlowMasks.cs
@@ -42,17 +42,11 @@ namespace GoldensMisc
 
 	public abstract class GlowingModItem : ModItem
     {
-		private Texture2D _glowMask;
-
-		public Texture2D GlowMask 
-		{
-			get { return _glowMask; }
-			set { _glowMask = value; }
-		}
+		public Texture2D GlowMask;
 
 		public override void PostDrawInInventory(SpriteBatch spriteBatch, Vector2 position, Rectangle frame, Color drawColor, Color itemColor, Vector2 origin, float scale)
 		{
-			Texture2D glowTexture = _glowMask;
+			Texture2D glowTexture = GlowMask;
 			Color color = Color.White;
 			color.A = 255;
 			spriteBatch.Draw(glowTexture, position, frame, color, 0f, origin, scale, SpriteEffects.None, 0f);
@@ -60,7 +54,7 @@ namespace GoldensMisc
 
 		public override void PostDrawInWorld(SpriteBatch spriteBatch, Color lightColor, Color alphaColor, float rotation, float scale, int whoAmI)
 		{
-			Texture2D glowTexture = _glowMask;
+			Texture2D glowTexture = GlowMask;
 			Color color = Color.White;
 			color.A = 255;
 			Rectangle glowTextureSize = new(0, 0, glowTexture.Width, glowTexture.Height);

--- a/MiscGlowMasks.cs
+++ b/MiscGlowMasks.cs
@@ -1,5 +1,6 @@
 ﻿
 using System;
+using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Terraria;
 using Terraria.GameContent;
@@ -35,6 +36,38 @@ namespace GoldensMisc
 				RodofWarping = null;
 				Loaded = false;
 			}
+		}
+
+	}
+
+	public abstract class GlowingModItem : ModItem
+    {
+		private Texture2D _glowMask;
+
+		public Texture2D GlowMask 
+		{
+			get { return _glowMask; }
+			set { _glowMask = value; }
+		}
+
+		public override void PostDrawInInventory(SpriteBatch spriteBatch, Vector2 position, Rectangle frame, Color drawColor, Color itemColor, Vector2 origin, float scale)
+		{
+			Texture2D glowTexture = _glowMask;
+			Color color = Color.White;
+			color.A = 255;
+			spriteBatch.Draw(glowTexture, position, frame, color, 0f, origin, scale, SpriteEffects.None, 0f);
+		}
+
+		public override void PostDrawInWorld(SpriteBatch spriteBatch, Color lightColor, Color alphaColor, float rotation, float scale, int whoAmI)
+		{
+			Texture2D glowTexture = _glowMask;
+			Color color = Color.White;
+			color.A = 255;
+			Rectangle glowTextureSize = new(0, 0, glowTexture.Width, glowTexture.Height);
+			Vector2 glowTextureOrigin = glowTexture.Size() * .5f;
+			Vector2 glowOffset = new((float)(Item.width / 2) - glowTextureOrigin.X, (float)(Item.height - glowTexture.Height));
+			Vector2 glowPosition = Item.position - Main.screenPosition + glowTextureOrigin + glowOffset;
+			spriteBatch.Draw(glowTexture, glowPosition, glowTextureSize, color, rotation, glowTextureOrigin, scale, SpriteEffects.None, 0f);
 		}
 	}
 }

--- a/Projectiles/UndyingSpear.cs
+++ b/Projectiles/UndyingSpear.cs
@@ -3,6 +3,8 @@ using Terraria;
 using Terraria.ID;
 using Terraria.Audio;
 using Terraria.ModLoader;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
 
 namespace GoldensMisc.Projectiles
 {
@@ -23,13 +25,12 @@ namespace GoldensMisc.Projectiles
 			Projectile.penetrate = 3;
 			Projectile.DamageType = DamageClass.Magic;
 			Projectile.ignoreWater = true;
-			Projectile.glowMask = MiscGlowMasks.UndyingSpearProjectile;
 			AIType = ProjectileID.JavelinFriendly;
 		}
 		
 		public override void OnHitNPC(NPC target, int damage, float knockback, bool crit)
 		{
-			int type = Main.rand.Next(2) == 0 ? ModContent.ProjectileType<MagicSpearMini>() : ModContent.ProjectileType<MagicSpearMiniAlt>();
+			int type = Main.rand.NextBool(2) ? ModContent.ProjectileType<MagicSpearMini>() : ModContent.ProjectileType<MagicSpearMiniAlt>();
 			
 			switch(Main.rand.Next(4))
 			{
@@ -57,5 +58,16 @@ namespace GoldensMisc.Projectiles
 				Main.dust[dust].scale = 1.5f;
 			}
 		}
-	}
+
+        public override void PostDraw(Color lightColor)
+        {
+			Texture2D glowTexture = MiscGlowMasks.UndyingSpearProjectile;
+			lightColor = Color.White;
+			lightColor.A = 255;
+			Vector2 glowPosition = Projectile.position;
+			Rectangle glowTextureSize = new(0, 0, glowTexture.Width, glowTexture.Height);
+			Vector2 glowTextureOrigin = glowTexture.Size() * .5f;
+			Main.EntitySpriteDraw(glowTexture, glowPosition, glowTextureSize, lightColor, Projectile.rotation, glowTextureOrigin, Projectile.scale, SpriteEffects.None, 0);
+        }
+    }
 }

--- a/Tiles/AncientHellforge.cs
+++ b/Tiles/AncientHellforge.cs
@@ -1,5 +1,6 @@
 ﻿
 using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
 using Terraria;
 using Terraria.DataStructures;
 using Terraria.ID;
@@ -42,7 +43,15 @@ namespace GoldensMisc.Tiles
 				Dust.NewDust(new Vector2(i * 16, j * 16), 16, 16, DustID.Torch);
 		}
 
-		public override void ModifyLight(int i, int j, ref float r, ref float g, ref float b)
+        public override bool PreDraw(int i, int j, SpriteBatch spriteBatch)
+        {
+			MinPick = 0;
+			if (j > Main.maxTilesY - 300)
+				MinPick = 60;
+			return true;
+        }
+
+        public override void ModifyLight(int i, int j, ref float r, ref float g, ref float b)
 		{
 			float rand = 0f;
 			//float rand = (float)Main.rand.Next(28, 42) * 0.005f;

--- a/Tiles/AutofisherTE.cs
+++ b/Tiles/AutofisherTE.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using Terraria;
+using Terraria.DataStructures;
 using Terraria.ID;
 using Terraria.Localization;
 using Terraria.ModLoader;
@@ -71,7 +72,7 @@ namespace GoldensMisc.Tiles
 					Main.projectile[bobberProj].type != ModContent.ProjectileType<AutofisherBobber>())
 				{
 					var bobberPos = new Point(Position.X + (facingRight ? 2 : 0), Position.Y).ToWorldCoordinates();
-					bobberProj = Projectile.NewProjectile(null, bobberPos, new Vector2(facingRight ? 3f : -3f, 0f), ModContent.ProjectileType<AutofisherBobber>(), 0, 0, ai1: this.ID);
+					bobberProj = Projectile.NewProjectile(new EntitySource_TileEntity(this), bobberPos, new Vector2(facingRight ? 3f : -3f, 0f), ModContent.ProjectileType<AutofisherBobber>(), 0, 0, ai1: this.ID);
 					Main.projectile[bobberProj].ai[1] = this.ID;
 					Main.projectile[bobberProj].netUpdate = true;
 					_fishingInfo = null;
@@ -82,7 +83,7 @@ namespace GoldensMisc.Tiles
 				}
 				else
 				{
-					if(Main.rand.Next(150) == 1)
+					if(Main.rand.NextBool(150))
 					{
 						FishingCooldown = 500;
 						int itemType;
@@ -187,7 +188,7 @@ namespace GoldensMisc.Tiles
 			int consumeChance = item.bait / 10 + 1;
 			if(item.type == ItemID.TruffleWorm)
 				item.stack--;
-			if(Main.rand.Next(consumeChance) == 0 && !(item.type == ItemID.TruffleWorm))
+			if(Main.rand.NextBool(consumeChance) && !(item.type == ItemID.TruffleWorm))
 				item.stack--;
 			if(item.stack <= 0)
 				item.SetDefaults(0);

--- a/Tiles/RedChimneyTE.cs
+++ b/Tiles/RedChimneyTE.cs
@@ -3,6 +3,7 @@ using System;
 using System.IO;
 using Microsoft.Xna.Framework;
 using Terraria;
+using Terraria.DataStructures;
 using Terraria.ID;
 using Terraria.ModLoader;
 using Terraria.ModLoader.IO;
@@ -27,26 +28,23 @@ namespace GoldensMisc.Tiles
 		
 		public override void Update()
 		{
-			if(CurrentState == State.Smoke && Main.rand.Next(9) == 0)
+			if(CurrentState == State.Smoke && Main.rand.NextBool(9))
 			{
-				var smokePos = new Vector2(Position.X * 16 + 16, Position.Y * 16 + 8);
-				var smokeVel = Vector2.Zero;
-				if (Main.windSpeedCurrent < 0f)
+				Vector2 smokePos = new (Position.X * 16 + 16, Position.Y * 16 + 8);
+				Vector2 smokeVel = Vector2.Zero;
+				int smokeType = Main.rand.Next(GoreID.ChimneySmoke1, GoreID.ChimneySmoke3);
+				byte rand = (byte)Main.rand.Next(4);
+				if (rand == 3)
 				{
-					smokeVel.X = -Main.windSpeedCurrent;
+					Gore.NewGore(new EntitySource_TileEntity(this), smokePos, smokeVel, smokeType, Main.rand.NextFloat() * 0.4f + 0.4f);
 				}
-				int smokeType = Main.rand.Next(825, 828);
-				if (Main.rand.Next(4) == 0)
+				else if (rand == 2)
 				{
-					Gore.NewGore(null, smokePos, smokeVel, smokeType, Main.rand.NextFloat() * 0.4f + 0.4f);
-				}
-				else if (Main.rand.Next(2) == 0)
-				{
-					Gore.NewGore(null, smokePos, smokeVel, smokeType, Main.rand.NextFloat() * 0.3f + 0.3f);
+					Gore.NewGore(new EntitySource_TileEntity(this), smokePos, smokeVel, smokeType, Main.rand.NextFloat() * 0.3f + 0.3f);
 				}
 				else
 				{
-					Gore.NewGore(null, smokePos, smokeVel, smokeType, Main.rand.NextFloat() * 0.2f + 0.2f);
+					Gore.NewGore(new EntitySource_TileEntity(this), smokePos, smokeVel, smokeType, Main.rand.NextFloat() * 0.2f + 0.2f);
 				}
 			}
 		}
@@ -70,12 +68,13 @@ namespace GoldensMisc.Tiles
 		
 		public override void SaveData(TagCompound tag)
 		{
-			tag["s"] = CurrentState;
+			tag["s"] = (byte)CurrentState;
 		}
 		
 		public override void LoadData(TagCompound tag)
 		{
-			CurrentState = (State)tag.GetByte("s");
+			if (tag.ContainsKey("s"))
+				CurrentState = (State)tag.GetByte("s");
 		}
 		
 		public override void NetSend(BinaryWriter writer)

--- a/build.txt
+++ b/build.txt
@@ -1,6 +1,6 @@
 ﻿displayName = Miscellania
 author = gardenapple
-version = 1.7.19
+version = 1.7.20
 homepage = http://forums.terraria.org/index.php?threads/miscellania.39500/
 hideResources = false
 hideCode = false


### PR DESCRIPTION
Fixing up things I have missed before 1.4.4
- Start transitioning to NextBool instead Next since it is 1 character shorter, and I think more readable.
- Missed using TileEntity entitysource on the autofisher and chimney(This can improve mod compatibility, no other effect).
- 1.4.0.1 made hellforges only mineable with 60+ pick power in the underworld. So I copied changes for the ancient one.
- Change the glowmask system to not use the vanilla array. This has been causing problems. I implemented it like the TModloader team recommends improving mod compatibility.
- Fix issues of the Red Chimney caused issues saving, the velocity thing you had seems to be overwritten by the goreloader so I removed it.

PS. ChimneySmokes have special AI that runs that includes assignment making any changes made here useless. Must have been a 1.4 addition.